### PR TITLE
[Optimisation, #7] cleanup spelling, change license, enhance readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.1.4
   - 2.2.0
   - 2.2.1
+  - 2.2.2
 before_install:
 - gem install bundler
 - export TZ=Australia/Canberra

--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,13 @@
-The MIT License (MIT)
-
 Copyright (c) 2015 Westfield Labs
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+    http://www.apache.org/licenses/LICENSE-2.0
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Datetime Helper
 
-A collection of useful utilities for projects that have to deal with dates, times, and timezones, with a focus on rails projects that enforce the use of Zulu Time.
+A collection of useful utilities for projects that have to deal with dates, times, and time zones, with particular utility for Rails projects that enforce the use of Zulu Time.
 
 ## Features
 
@@ -8,7 +8,7 @@ A collection of useful utilities for projects that have to deal with dates, time
 2. An `ActiveModel` validator called `zulu_time`, and
 3. An `ActiveModel::Serializer` helper method called `in_zulu_time`.
 
-Each feature can be required individually so you can use the `rspec` matcher, `ActiveModel` validtor, or `ActiveModel::Serializer` helper in isolation.
+Each feature can be required individually so you can use the `rspec` matcher, `ActiveModel` validator, or `ActiveModel::Serializer` helper in isolation.
 
 [![Build Status](https://travis-ci.org/westfieldlabs/datetime_helper.svg?branch=master)](https://travis-ci.org/westfieldlabs/datetime_helper)
 
@@ -21,7 +21,7 @@ Each feature can be required individually so you can use the `rspec` matcher, `A
 
 ## TL;DR
 
-Zulu Time is an ISO 8601 formatted string representing a `datetime` but in the time zone UTC+0. This makes it trivial for client applications to display correctly in their local, or other nominated time zones.
+Zulu Time is an ISO 8601 formatted string representing a `datetime` but in the time zone UTC+0. This makes it trivial for client applications to display dates and times correctly in their local, or other nominated time zones.
 
 Enforcing Zulu Time across a range of projects requires a common approach to how you validate incoming strings, how you represent the data internally, how you serialise the data back out into strings, and how you test all that consistently and efficiently.
 
@@ -32,7 +32,7 @@ Enforcing Zulu Time across a range of projects requires a common approach to how
 Put this in your `Gemfile`
 
 ```ruby
-gem 'datetime_helper', git: "http://github.com/westfieldlabs/datetime_helper.git"
+gem 'datetime_helper'
 ```
 
 ### Using the `be_zulu_time` matcher in your `RSpec` tests
@@ -53,9 +53,9 @@ And put this in your `rspec` tests.
 it {expect(subject[:deleted_at]).to be_zulu_time}
 ```
 
-### Validating `ActiveModel` fields to ensure they hold UTC+0 `date-time` data
+### Validating `ActiveModel` fields to ensure they hold UTC+0 `datetime` data
 
-Put this in your model for datetime fields that must be stored as UTC+0
+Put this in your model for `datetime` fields that must be stored as UTC+0
 
 First be sure you `require 'datetime_helper/active_model'`
 
@@ -111,7 +111,20 @@ bundle install
 rake
 ```
 
-The tests offer good insight into how to use these utilities.
+The tests offer insight into how to use these utilities.
+
+## License
+
+The `datetime_helper` is © 2015 Westfield Labs and is available for use under the [MIT License](LICENSE).
+
+## Version history
+
+|Version| Comments                                   |
+|:------|:-------------------------------------------|
+|`0.0.1`| First draft — only the rspec matcher       |
+|`0.0.2`| Added the `ActiveModel` validator          |
+|`0.0.3`| Added the `ActiveModel::Serializer` helper |
+|`1.0.0`| Cleaned up for first official release      |
 
 ## To contribute
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Datetime Helper
+# The Datetime Helper
 
 A collection of useful utilities for projects that have to deal with dates, times, and time zones, with particular utility for Rails projects that enforce the use of Zulu Time.
 
@@ -118,7 +118,7 @@ Contributions are encouraged. See the [contribution instructions](contributing.m
 
 ## License
 
-The `datetime_helper` is © 2015 Westfield Labs and is available for use under the [Apache 2.0](LICENSE) license.
+The `Datetime Helper` is © 2015 Westfield Labs and is available for use under the [Apache 2.0](LICENSE) license.
 
 ## Version history
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ A collection of useful utilities for projects that have to deal with dates, time
 
 ## Features
 
-1. An `rspec` matcher called `be_zulu_time`,
-2. An `ActiveModel` validator called `zulu_time`, and
-3. An `ActiveModel::Serializer` helper method called `in_zulu_time`.
+1. A base method called `is_zulu_time?`, 
+2. An `rspec` matcher called `be_zulu_time`,
+3. An `ActiveModel` validator called `zulu_time`, and
+4. An `ActiveModel::Serializer` helper method called `in_zulu_time`.
 
 Each feature can be required individually so you can use the `rspec` matcher, `ActiveModel` validator, or `ActiveModel::Serializer` helper in isolation.
 
@@ -14,7 +15,7 @@ Each feature can be required individually so you can use the `rspec` matcher, `A
 
 ## Requirements
 
-1. `Ruby`, `Bundler`, etc. The usual suspects. (tested against Ruby 2.0.0 and up)
+1. `Ruby`, `Bundler`, etc. The usual suspects. (Tested against Ruby 2.0.0 and up)
 2. `rspec` if you `require 'datetime_helper/rspec'`
 3. `active_model` if you `require 'datetime_helper/active_model'`
 4. `active_model_serializers` if you `require 'datetime_helper/active_model_serialiser'`
@@ -23,9 +24,9 @@ Each feature can be required individually so you can use the `rspec` matcher, `A
 
 Zulu Time is an ISO 8601 formatted string representing a `datetime` but in the time zone UTC+0. This makes it trivial for client applications to display dates and times correctly in their local, or other nominated time zones.
 
-Enforcing Zulu Time across a range of projects requires a common approach to how you validate incoming strings, how you represent the data internally, how you serialise the data back out into strings, and how you test all that consistently and efficiently.
+Enforcing Zulu Time across a range of projects requires a common approach to validating incoming strings, representing the data internally, serialising the data back out into strings, and testing date and time fields.
 
-`Datetime Helper` was developed to provide that common approach, and it is available as an open source project because we believe it is generically useful.
+The `Datetime Helper` was developed to provide that common approach, and it is available as an open source project because we believe it is generically useful.
 
 ## To use
 
@@ -33,6 +34,12 @@ Put this in your `Gemfile`
 
 ```ruby
 gem 'datetime_helper'
+```
+
+### Testing a string to see if it is a Zulu Time formatted string
+
+```ruby
+DatetimeHelper.is_zulu_time? "some_string"
 ```
 
 ### Using the `be_zulu_time` matcher in your `RSpec` tests
@@ -55,8 +62,6 @@ it {expect(subject[:deleted_at]).to be_zulu_time}
 
 ### Validating `ActiveModel` fields to ensure they hold UTC+0 `datetime` data
 
-Put this in your model for `datetime` fields that must be stored as UTC+0
-
 First be sure you `require 'datetime_helper/active_model'`
 
 Then your model class can add:
@@ -68,12 +73,6 @@ validates :updated_at, zulu_time: true
 ```
 
 This will verify that a `Time` is supplied at `UTC+0`, or that a `DateTime` has `.zone == "+00:00"`.
-
-You can also simply test a string to see if it is a Zulu Time string using
-
-```ruby
-DatetimeHelper.is_zulu_time? "some_string"
-```
 
 ### Enforcing `ActiveModel::Serializer`  Zulu Time string formats
 
@@ -113,9 +112,13 @@ rake
 
 The tests offer insight into how to use these utilities.
 
+## To contribute
+
+Contributions are encouraged. See the [contribution instructions](contributing.md) for the preferred contribution process.
+
 ## License
 
-The `datetime_helper` is © 2015 Westfield Labs and is available for use under the [MIT License](LICENSE).
+The `datetime_helper` is © 2015 Westfield Labs and is available for use under the [Apache 2.0](LICENSE) license.
 
 ## Version history
 
@@ -125,7 +128,3 @@ The `datetime_helper` is © 2015 Westfield Labs and is available for use under t
 |`0.0.2`| Added the `ActiveModel` validator          |
 |`0.0.3`| Added the `ActiveModel::Serializer` helper |
 |`1.0.0`| Cleaned up for first official release      |
-
-## To contribute
-
-Contributions are welcome.  See the [contribution instructions](contributing.md) for the preferred contribution process.

--- a/datetime_helper.gemspec
+++ b/datetime_helper.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["davesag"]
   spec.email         = ["davesag@gmail.com"]
   spec.summary       = "A collection of useful helpers for projects which have to deal with dates, times, and time zones."
-  spec.description   = "The `Datetime Helper` was developed to provide a common approach to validating incoming strings, representing the data internally, serialising the data back out into strings, and testing date and time fields."
+  spec.description   = "The `Datetime Helper` was developed to provide a common approach to validating incoming datetime data, representing that data internally, serialising it back out into strings, and testing of date and time fields."
   spec.homepage      = "https://github.com/westfieldlabs/datetime_helper"
   spec.license       = "Apache 2.0"
 

--- a/datetime_helper.gemspec
+++ b/datetime_helper.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "A collection of useful helpers for projects which have to deal with dates, times, and timezones."
   spec.description   = "Enforcing Zulu Time across a range of projects requires a common approach to how you validate incoming strings, how you represent the data internally, how you serialise the data back out into strings, and how you test all that consistently and efficiently. The Datetime Helpers provide that common approach."
   spec.homepage      = "https://github.com/westfieldlabs/datetime_helper"
-  spec.license       = "MIT"
+  spec.license       = "Apache 2.0"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/datetime_helper.gemspec
+++ b/datetime_helper.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.version       = DatetimeHelper::VERSION
   spec.authors       = ["davesag"]
   spec.email         = ["davesag@gmail.com"]
-  spec.summary       = "A collection of useful helpers for projects which have to deal with dates, times, and timezones."
-  spec.description   = "Enforcing Zulu Time across a range of projects requires a common approach to how you validate incoming strings, how you represent the data internally, how you serialise the data back out into strings, and how you test all that consistently and efficiently. The Datetime Helpers provide that common approach."
+  spec.summary       = "A collection of useful helpers for projects which have to deal with dates, times, and time zones."
+  spec.description   = "The `Datetime Helper` was developed to provide a common approach to validating incoming strings, representing the data internally, serialising the data back out into strings, and testing date and time fields."
   spec.homepage      = "https://github.com/westfieldlabs/datetime_helper"
   spec.license       = "Apache 2.0"
 

--- a/lib/datetime_helper/version.rb
+++ b/lib/datetime_helper/version.rb
@@ -1,3 +1,3 @@
 module DatetimeHelper
-  VERSION = "0.0.3"
+  VERSION = "1.0.0"
 end

--- a/spec/validators/zulu_time_active_model_validator_spec.rb
+++ b/spec/validators/zulu_time_active_model_validator_spec.rb
@@ -2,8 +2,13 @@ require_relative '../spec_helper'
 require "datetime_helper/active_model"
 
 describe DatetimeHelper::Validators::ZuluTimeValidator do
-  let(:validator) { described_class.new({attributes: [:updated_at]})}
-  let(:model)     { double('model') }
+  let(:validator)      { described_class.new({attributes: [:updated_at]})}
+  let(:model)          { double('model') }
+
+  # if, by chance, you happen to be running these tests
+  # on a machine set to UTC+0 then the local time tests
+  # won't really be a valid test.
+  let(:already_in_utc) { Time.now.utc == Time.now.getlocal }
   
   before :each do
     allow(model).to receive_message_chain('errors').and_return([])
@@ -22,6 +27,7 @@ describe DatetimeHelper::Validators::ZuluTimeValidator do
   context "given a local Time" do
     let(:invalid_time) { Time.now.getlocal }
     it "is not accepted as valid" do
+      pending "Local Time is UTC so skipping test" if already_in_utc
       expect(model.errors[]).to receive('<<')
       validator.validate_each(model, 'updated_at', invalid_time)
     end
@@ -38,6 +44,7 @@ describe DatetimeHelper::Validators::ZuluTimeValidator do
   context "given a local DateTime" do
     let(:invalid_time) { DateTime.now }
     it "is not accepted as valid" do
+      pending "Local Time is UTC so skipping test" if already_in_utc
       expect(model.errors[]).to receive('<<')
       validator.validate_each(model, 'updated_at', invalid_time)
     end


### PR DESCRIPTION
Also skip the local time tests in the rare case that the tests are running at UTC+0.  The CI's local time is set to `Australia/Canberra` to avert this issue but there is no predicting where someone else might run the tests.  Other solutions have also been proposed but this is, for now, the absolute simplest.
