### PR TITLE
31 Allow DateTime strings on zulu time pattern

### DIFF
--- a/lib/datetime_helper.rb
+++ b/lib/datetime_helper.rb
@@ -2,7 +2,7 @@ require "datetime_helper/version"
 
 module DatetimeHelper
 
-  ZULU_TIME_PATTERN = /^(\d{4})-([0-1][0-9])-([0-3]\d{1})T([0-2]\d{1}):([0-5]\d{1}):([0-5]\d{1})(\.[0-9]{1,3})?Z$/
+  ZULU_TIME_PATTERN = /^(\d{4})-([0-1][0-9])-([0-3]\d{1})T([0-2]\d{1}):([0-5]\d{1}):([0-5]\d{1})((\.[0-9]{1,3})?(Z|\+00:00))$/
 
   class << self
     def is_zulu_time?(something)

--- a/lib/datetime_helper/version.rb
+++ b/lib/datetime_helper/version.rb
@@ -1,3 +1,3 @@
 module DatetimeHelper
-  VERSION = "1.0.5"
+  VERSION = "1.0.6"
 end

--- a/spec/datetime_helper_spec.rb
+++ b/spec/datetime_helper_spec.rb
@@ -8,6 +8,12 @@ describe DatetimeHelper do
       it { expect(DatetimeHelper.is_zulu_time?(valid_string)).to eq true }
     end
 
+    context "given a valid Zulu Datetime string" do
+      let(:valid_string) { "2016-11-10T02:38:05+00:00" }
+      it { expect{ Time.parse(valid_string)}.to_not raise_error }
+      it { expect(DatetimeHelper.is_zulu_time?(valid_string)).to eq true }
+    end
+
     context "given a valid ISO 8601 string that's not Zulu Time" do
       let(:invalid_string) { Time.now.iso8601 }
       it { expect{ Time.parse(invalid_string)}.to_not raise_error }


### PR DESCRIPTION
The is_zulu_time? method accepts a time object, a datetime object and a string time, but when we pass a string time, it fails to validate datetime strings. 
This PR makes the is_zulu_time? method accept datetime strings
Example of string that would fail on the master branch: "2016-11-10T02:38:05+00:00"