### PR TITLE
Fix active_model_serializers version

### DIFF
--- a/datetime_helper.gemspec
+++ b/datetime_helper.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'rspec',       '~> 3'
   spec.add_runtime_dependency 'activemodel', '~> 4'
-  spec.add_runtime_dependency 'active_model_serializers'
+  spec.add_runtime_dependency 'active_model_serializers', '~> 0.9.0'
 
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.4"


### PR DESCRIPTION
To solve the problem on travis builds we have to use the version 0.9.0 of the active_model_serializers gem. 
